### PR TITLE
Fix NullPointerException on some devices

### DIFF
--- a/app/src/main/java/com/communitycode/amps/main/battery/UnofficialBatteryMethod.java
+++ b/app/src/main/java/com/communitycode/amps/main/battery/UnofficialBatteryMethod.java
@@ -73,7 +73,7 @@ public class UnofficialBatteryMethod implements BatteryMethodInterface {
         return filePath.equals(b.filePath)
                 && reader == b.reader
                 && scale == b.scale
-                && chargeField.equals(b.chargeField)
-                && dischargeField.equals(b.dischargeField);
+                && (chargeField == b.chargeField || (chargeField != null && chargeField.equals(b.chargeField)))
+                && (dischargeField == b.dischargeField || (dischargeField != null && dischargeField.equals(b.dischargeField)));
     }
 }


### PR DESCRIPTION
I have made a simple fix in comparison which failed on null value. Amps did crash on my Nexus 7 without the fix.